### PR TITLE
fixed url link normalize in Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
 }
 
 pearLink.normalize = (link) => {
-  if (link.startsWith('file://')) { // if link has url format, separator is alway '/' even in Windows
+  if (link.startsWith('file://')) { // if link has url format, separator is always '/' even in Windows
     return link.endsWith('/') ? link.slice(0, -1) : link
   } else {
     return link.endsWith(path.sep) ? link.slice(0, -1) : link

--- a/index.js
+++ b/index.js
@@ -98,7 +98,11 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
 }
 
 pearLink.normalize = (link) => {
-  return link.endsWith(path.sep) ? link.slice(0, -1) : link
+  if (link.startsWith('file://')) { // if link has url format, separator is alway '/' even in Windows
+    return link.endsWith('/') ? link.slice(0, -1) : link
+  } else {
+    return link.endsWith(path.sep) ? link.slice(0, -1) : link
+  }
 }
 
 module.exports = pearLink

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,6 +8,7 @@ const ALIASES = {
   runtime: hypercoreid.decode('nkw138nybdx6mtf98z497czxogzwje5yzu585c66ofba854gw3ro')
 }
 const pearLink = require('../index.js')(ALIASES)
+const normalize = require('../index.js').normalize
 
 test('pear://<key>', (t) => {
   t.plan(5)
@@ -138,6 +139,11 @@ test('Unsupported protocol', (t) => {
 test('empty link', (t) => {
   t.plan(1)
   t.exception(() => { pearLink() }, /No link specified/)
+})
+
+test('url link normalize', (t) => {
+  t.plan(1)
+  t.is(normalize('file://a/b/'), 'file://a/b')
 })
 
 function cwd () {


### PR DESCRIPTION
This pull request fixed pear link normalization in Windows when provided in url format:

Example:

`
const normalizedLink = pearLink.normalize('file://a/b/')
`

Since '/' is not the path.sep in Windows, normalization fails.