### PR TITLE
New helper function: `pearLink.origin (link)`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict'
 const path = require('path')
+const { pathToFileURL } = require('url-file-url')
 const { decode } = require('hypercore-id-encoding')
 const FILE = 'file:'
 const PEAR = 'pear:'
@@ -25,7 +26,7 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
         protocol,
         pathname,
         hash,
-        origin: pearLink.normalize(url),
+        origin: pearLink.normalize(pathToFileURL(pathname).href),
         drive: {
           key: null,
           length: null,

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 const path = require('path')
 const { pathToFileURL } = require('url-file-url')
-const { decode } = require('hypercore-id-encoding')
+const { encode, decode } = require('hypercore-id-encoding')
 const FILE = 'file:'
 const PEAR = 'pear:'
 const DOUB = '//'
@@ -63,7 +63,7 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
 
       const alias = aliases[keyOrAlias] ? keyOrAlias : null
       const key = aliases[keyOrAlias] || decode(keyOrAlias)
-      const origin = keyToAlias(key) ? `${protocol}//${keyToAlias(key)}` : `${protocol}//${keyOrAlias}`
+      const origin = keyToAlias(key) ? `${protocol}//${keyToAlias(key)}` : `${protocol}//${encode(key)}`
 
       if (parts === 3) { // pear://fork.length.keyOrAlias[/some/path]
         if (!Number.isInteger(+fork) || !Number.isInteger(+length)) throw error('Incorrect hostname')

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 const path = require('path')
-const { decode, normalize } = require('hypercore-id-encoding')
+const { decode } = require('hypercore-id-encoding')
 const FILE = 'file:'
 const PEAR = 'pear:'
 const DOUB = '//'
@@ -39,7 +39,7 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
 
       if (parts === 1) { // pear://keyOrAlias[/some/path]
         const key = aliases[hostname] || decode(hostname)
-        const origin = keyToAlias(key) ? `${protocol}//${keyToAlias(key)}` : `${protocol}//${normalize(key)}`
+        const origin = keyToAlias(key) ? `${protocol}//${keyToAlias(key)}` : `${protocol}//${key.toString('hex')}`
         const alias = aliases[hostname] ? hostname : null
         return {
           protocol,
@@ -62,7 +62,7 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
 
       const alias = aliases[keyOrAlias] ? keyOrAlias : null
       const key = aliases[keyOrAlias] || decode(keyOrAlias)
-      const origin = keyToAlias(key) ? `${protocol}//${keyToAlias(key)}` : `${protocol}//${normalize(key)}`
+      const origin = keyToAlias(key) ? `${protocol}//${keyToAlias(key)}` : `${protocol}//${key.toString('hex')}`
 
       if (parts === 3) { // pear://fork.length.keyOrAlias[/some/path]
         if (!Number.isInteger(+fork) || !Number.isInteger(+length)) throw error('Incorrect hostname')

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
         protocol,
         pathname,
         hash,
-        origin: url.startsWith(FILE + DOUB) ? pearLink.normalize(url) : pearLink.normalize(pathToFileURL(url).href),
+        origin: !isPath ? pearLink.normalize(url) : pearLink.normalize(pathToFileURL(url).href),
         drive: {
           key: null,
           length: null,

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
 
       const alias = aliases[keyOrAlias] ? keyOrAlias : null
       const key = aliases[keyOrAlias] || decode(keyOrAlias)
-      const origin = keyToAlias(key) ? `${protocol}//${keyToAlias(key)}` : `${protocol}//${key.toString('hex')}`
+      const origin = keyToAlias(key) ? `${protocol}//${keyToAlias(key)}` : `${protocol}//${keyOrAlias}`
 
       if (parts === 3) { // pear://fork.length.keyOrAlias[/some/path]
         if (!Number.isInteger(+fork) || !Number.isInteger(+length)) throw error('Incorrect hostname')

--- a/index.js
+++ b/index.js
@@ -105,4 +105,13 @@ pearLink.normalize = (link) => {
   }
 }
 
+pearLink.root = (link) => {
+  const url = new URL(link)
+  if (url.protocol === PEAR) {
+    return `${PEAR + DOUB}${url.hostname}`
+  } else {
+    return pearLink.normalize(link)
+  }
+}
+
 module.exports = pearLink

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
         protocol,
         pathname,
         hash,
+        origin,
         drive: {
           key: null,
           length: null,
@@ -42,6 +43,7 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
           protocol,
           pathname,
           hash,
+          origin,
           drive: {
             key: aliases[hostname] || decode(hostname),
             length: 0,
@@ -64,6 +66,7 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
           protocol,
           pathname,
           hash,
+          origin,
           drive: {
             key: aliases[keyOrAlias] || decode(keyOrAlias),
             length: Number(length),
@@ -81,6 +84,7 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
           protocol,
           pathname,
           hash,
+          origin,
           drive: {
             key: aliases[keyOrAlias] || decode(keyOrAlias),
             length: Number(length),
@@ -103,23 +107,6 @@ pearLink.normalize = (link) => {
     return link.endsWith('/') ? link.slice(0, -1) : link
   } else {
     return link.endsWith(path.sep) ? link.slice(0, -1) : link
-  }
-}
-
-pearLink.origin = (link) => {
-  if (link.startsWith(PEAR + DOUB)) {
-    try {
-      const key = encode(pearLink()(link).drive.key)
-      if (key) return `${PEAR + DOUB}${key}`
-    } catch (err) { // future-proof any alias
-      const url = new URL(link)
-      return `${PEAR + DOUB}${url.hostname}`
-    }
-  }
-  if (link.startsWith(FILE + DOUB)) {
-    return pearLink.normalize(link)
-  } else {
-    return pearLink.normalize(pathToFileURL(link).href)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
         protocol,
         pathname,
         hash,
-        origin: pearLink.normalize(pathToFileURL(pathname).href),
+        origin: url.startsWith(FILE + DOUB) ? pearLink.normalize(url) : pearLink.normalize(pathToFileURL(url).href),
         drive: {
           key: null,
           length: null,

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict'
 const path = require('path')
+const { pathToFileURL } = require('url-file-url')
 const { decode } = require('hypercore-id-encoding')
 const FILE = 'file:'
 const PEAR = 'pear:'
@@ -98,7 +99,7 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
 }
 
 pearLink.normalize = (link) => {
-  if (link.startsWith('file://')) { // if link has url format, separator is always '/' even in Windows
+  if (link.startsWith(FILE + DOUB)) { // if link has url format, separator is always '/' even in Windows
     return link.endsWith('/') ? link.slice(0, -1) : link
   } else {
     return link.endsWith(path.sep) ? link.slice(0, -1) : link
@@ -106,12 +107,14 @@ pearLink.normalize = (link) => {
 }
 
 pearLink.root = (link) => {
-  const url = new URL(link)
-  if (url.protocol === PEAR) {
+  if (link.startsWith(PEAR + DOUB)) {
+    const url = new URL(link)
     return `${PEAR + DOUB}${url.hostname}`
-  } else {
+  }
+  if (link.startsWith(FILE + DOUB)) {
     return pearLink.normalize(link)
   }
+  return pearLink.normalize(pathToFileURL(link).href)
 }
 
 module.exports = pearLink

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ pearLink.normalize = (link) => {
   }
 }
 
-pearLink.root = (link) => {
+pearLink.origin = (link) => {
   if (link.startsWith(PEAR + DOUB)) {
     const url = new URL(link)
     return `${PEAR + DOUB}${url.hostname}`

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 const path = require('path')
 const { pathToFileURL } = require('url-file-url')
-const { encode, decode } = require('hypercore-id-encoding')
+const { decode } = require('hypercore-id-encoding')
 const FILE = 'file:'
 const PEAR = 'pear:'
 const DOUB = '//'
@@ -63,7 +63,7 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
 
       const alias = aliases[keyOrAlias] ? keyOrAlias : null
       const key = aliases[keyOrAlias] || decode(keyOrAlias)
-      const origin = keyToAlias(key) ? `${protocol}//${keyToAlias(key)}` : `${protocol}//${encode(key)}`
+      const origin = keyToAlias(key) ? `${protocol}//${keyToAlias(key)}` : `${protocol}//${keyOrAlias}`
 
       if (parts === 3) { // pear://fork.length.keyOrAlias[/some/path]
         if (!Number.isInteger(+fork) || !Number.isInteger(+length)) throw error('Incorrect hostname')

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 const path = require('path')
 const { pathToFileURL } = require('url-file-url')
-const { decode } = require('hypercore-id-encoding')
+const { encode, decode } = require('hypercore-id-encoding')
 const FILE = 'file:'
 const PEAR = 'pear:'
 const DOUB = '//'
@@ -108,13 +108,19 @@ pearLink.normalize = (link) => {
 
 pearLink.origin = (link) => {
   if (link.startsWith(PEAR + DOUB)) {
-    const url = new URL(link)
-    return `${PEAR + DOUB}${url.hostname}`
+    try {
+      const key = encode(pearLink()(link).drive.key)
+      if (key) return `${PEAR + DOUB}${key}`
+    } catch (err) { // future-proof any alias
+      const url = new URL(link)
+      return `${PEAR + DOUB}${url.hostname}`
+    }
   }
   if (link.startsWith(FILE + DOUB)) {
     return pearLink.normalize(link)
+  } else {
+    return pearLink.normalize(pathToFileURL(link).href)
   }
-  return pearLink.normalize(pathToFileURL(link).href)
 }
 
 module.exports = pearLink

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 const path = require('path')
 const { pathToFileURL } = require('url-file-url')
-const { decode } = require('hypercore-id-encoding')
+const { encode, decode } = require('hypercore-id-encoding')
 const FILE = 'file:'
 const PEAR = 'pear:'
 const DOUB = '//'
@@ -10,7 +10,7 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
     if (!url) throw error('No link specified')
     const isPath = url.startsWith(PEAR + DOUB) === false && url.startsWith(FILE + DOUB) === false
     const isRelativePath = isPath && url[0] !== '/' && url[1] !== ':'
-    const keyToAlias = key => Object.keys(aliases).find(alias => aliases[alias].equals(key))
+    const keys = Object.fromEntries(Object.entries(aliases).map(([k, v]) => [encode(v), k]))
     const {
       protocol,
       pathname,
@@ -40,7 +40,7 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
 
       if (parts === 1) { // pear://keyOrAlias[/some/path]
         const key = aliases[hostname] || decode(hostname)
-        const origin = keyToAlias(key) ? `${protocol}//${keyToAlias(key)}` : `${protocol}//${hostname}`
+        const origin = keys[encode(key)] ? `${protocol}//${keys[encode(key)]}` : `${protocol}//${hostname}`
         const alias = aliases[hostname] ? hostname : null
         return {
           protocol,
@@ -63,7 +63,7 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
 
       const alias = aliases[keyOrAlias] ? keyOrAlias : null
       const key = aliases[keyOrAlias] || decode(keyOrAlias)
-      const origin = keyToAlias(key) ? `${protocol}//${keyToAlias(key)}` : `${protocol}//${keyOrAlias}`
+      const origin = keys[encode(key)] ? `${protocol}//${keys[encode(key)]}` : `${protocol}//${keyOrAlias}`
 
       if (parts === 3) { // pear://fork.length.keyOrAlias[/some/path]
         if (!Number.isInteger(+fork) || !Number.isInteger(+length)) throw error('Incorrect hostname')

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function pearLink (aliases = {}, error = (msg) => { throw new Error(msg) }) {
 
       if (parts === 1) { // pear://keyOrAlias[/some/path]
         const key = aliases[hostname] || decode(hostname)
-        const origin = keyToAlias(key) ? `${protocol}//${keyToAlias(key)}` : `${protocol}//${key.toString('hex')}`
+        const origin = keyToAlias(key) ? `${protocol}//${keyToAlias(key)}` : `${protocol}//${hostname}`
         const alias = aliases[hostname] ? hostname : null
         return {
           protocol,

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/holepunchto/pear-link#readme",
   "dependencies": {
     "hypercore-id-encoding": "^1.2.0",
+    "url-file-url": "^1.0.5",
     "which-runtime": "^1.2.1"
   },
   "devDependencies": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -151,8 +151,8 @@ test('url link origin', (t) => {
   t.plan(4)
   t.is(origin('/Users/user/app/'), 'file:///Users/user/app')
   t.is(origin('file:///Users/user/app/'), 'file:///Users/user/app')
+  t.is(origin('pear://2.2455.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo/some/path#lochash'), 'pear://b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo')
   t.is(origin('pear://keet/route/to/entry.js#fragment'), 'pear://keet')
-  t.is(origin('pear://2.2455.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo/some/path#lochash', 'pear://b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo'))
 })
 
 function cwd () {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -155,12 +155,10 @@ test('url link normalize', (t) => {
 })
 
 test('origin', (t) => {
-  t.plan(5)
+  t.plan(3)
   t.is(pearLink('file:///Users/user/app/').origin, 'file:///Users/user/app')
   t.is(pearLink('pear://2.2455.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo/some/path#lochash').origin, 'pear://b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo')
   t.is(pearLink('pear://keet/route/to/entry.js#fragment').origin, 'pear://keet')
-  t.is(pearLink('pear://future').origin, 'pear://future')
-  t.is(pearLink('pear://future/route/to/entry.js#fragment').origin, 'pear://future')
 })
 
 test('origin: keyToAlias', (t) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -148,12 +148,21 @@ test('url link normalize', (t) => {
 })
 
 test('url link origin', (t) => {
-  t.plan(5)
-  t.is(origin('/Users/user/app/'), 'file:///Users/user/app')
+  t.plan(4)
   t.is(origin('file:///Users/user/app/'), 'file:///Users/user/app')
   t.is(origin('pear://2.2455.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo/some/path#lochash'), 'pear://b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo')
   t.is(origin('pear://keet/route/to/entry.js#fragment'), 'pear://keet')
   t.is(origin('pear://future'), 'pear://future')
+})
+
+test('Unix: url link origin', { skip: isWindows }, (t) => {
+  t.plan(1)
+  t.is(origin('/Users/user/app/'), 'file:///Users/user/app')
+})
+
+test('Windows: url link origin', { skip: !isWindows }, (t) => {
+  t.plan(1)
+  t.is(origin('C:\\Users\\user\\app\\'), 'file:///C:/Users/user/app')
 })
 
 function cwd () {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,6 +9,7 @@ const ALIASES = {
 }
 const pearLink = require('../index.js')(ALIASES)
 const normalize = require('../index.js').normalize
+const root = require('../index.js').root
 
 test('pear://<key>', (t) => {
   t.plan(5)
@@ -144,6 +145,18 @@ test('empty link', (t) => {
 test('url link normalize', (t) => {
   t.plan(1)
   t.is(normalize('file://a/b/'), 'file://a/b')
+})
+
+test('url link root', (t) => {
+  t.plan(7)
+  t.is(root('pear://keet/nested/#fragment'), 'pear://keet')
+  t.is(root('file:///Users/user/app/'), 'file:///Users/user/app')
+  const link = 'pear://a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2'
+  t.is(root(`${link}/`), link)
+  t.is(root(`${link}/#fragment`), link)
+  t.is(root(`${link}/nested`), link)
+  t.is(root(`${link}/nested/entrypoint.html`), link)
+  t.is(root(`${link}/nested/entrypoint.html#fragment`), link)
 })
 
 function cwd () {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,26 +9,27 @@ const ALIASES = {
 }
 const pearLink = require('../index.js')(ALIASES)
 const normalize = require('../index.js').normalize
-const origin = require('../index.js').origin
 
 test('pear://<key>', (t) => {
   t.plan(5)
-  const { protocol, pathname, drive: { length, fork, key } } = pearLink('pear://a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2')
+  const { protocol, pathname, origin, drive: { length, fork, key } } = pearLink('pear://a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2')
   t.is(protocol, 'pear:')
   t.is(length, 0)
   t.is(fork, null)
   t.is(key.toString('hex'), 'a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2')
   t.absent(pathname)
+  t.is(origin, 'pear://a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2')
 })
 
 test('pear://key/pathname', (t) => {
   t.plan(5)
-  const { protocol, pathname, drive: { length, fork, key } } = pearLink('pear://a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2/some/path.js')
+  const { protocol, pathname, origin, drive: { length, fork, key } } = pearLink('pear://a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2/some/path.js')
   t.is(protocol, 'pear:')
   t.is(length, 0)
   t.is(fork, null)
   t.is(key.toString('hex'), 'a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2')
   t.is(pathname, '/some/path.js')
+  t.is(origin, 'pear://a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2')
 })
 
 test('pear://invalid-key', (t) => {
@@ -40,37 +41,41 @@ test('pear://invalid-key', (t) => {
 
 test('pear://<alias>', (t) => {
   t.plan(6)
-  const { protocol, pathname, drive: { length, fork, key, alias } } = pearLink('pear://keet')
+  const { protocol, pathname, origin, drive: { length, fork, key, alias } } = pearLink('pear://keet')
   t.is(protocol, 'pear:')
   t.is(length, 0)
   t.is(fork, null)
   t.is(alias, 'keet')
   t.is(key.toString('hex'), ALIASES.keet.toString('hex'))
   t.absent(pathname)
+  t.is(origin, 'pear://keet')
 })
 
 test('pear://alias/path', (t) => {
   t.plan(5)
-  const { protocol, pathname, drive: { length, fork, key } } = pearLink('pear://keet/some/path')
+  const { protocol, pathname, origin, drive: { length, fork, key } } = pearLink('pear://keet/some/path')
   t.is(protocol, 'pear:')
   t.is(length, 0)
   t.is(fork, null)
   t.is(key.toString('hex'), ALIASES.keet.toString('hex'))
   t.is(pathname, '/some/path')
+  t.is(origin, 'pear://keet')
 })
 
 test('pear://<fork>.<length>.<key>', (t) => {
   t.plan(3)
-  const { protocol, drive } = pearLink('pear://2.2455.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo')
+  const { protocol, origin, drive } = pearLink('pear://2.2455.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo')
   t.is(protocol, 'pear:')
   t.is(drive.length, 2455)
   t.is(drive.fork, 2)
+  t.is(origin, 'pear://b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo')
 })
 
 test('pear://<fork>.<length>.<key>.<dhash>/some/path#lochash', (t) => {
   t.plan(7)
-  const { protocol, pathname, drive, hash } = pearLink('pear://2.2455.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo/some/path#lochash')
+  const { protocol, pathname, origin, drive, hash } = pearLink('pear://2.2455.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo/some/path#lochash')
   t.is(pathname, '/some/path')
+  t.is(origin, 'pear://b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo')
   t.is(protocol, 'pear:')
   t.is(hash, '#lochash')
   t.is(drive.length, 2455)
@@ -81,20 +86,22 @@ test('pear://<fork>.<length>.<key>.<dhash>/some/path#lochash', (t) => {
 
 test('pear://alias/path', (t) => {
   t.plan(5)
-  const { protocol, pathname, drive: { length, fork, key } } = pearLink('pear://keet/some/path')
+  const { protocol, pathname, origin, drive: { length, fork, key } } = pearLink('pear://keet/some/path')
   t.is(protocol, 'pear:')
   t.is(length, 0)
   t.is(fork, null)
   t.is(key.toString('hex'), ALIASES.keet.toString('hex'))
   t.is(pathname, '/some/path')
+  t.is(origin, 'pear://keet')
 })
 
 test('file:///path', (t) => {
   t.plan(3)
-  const { drive, protocol, pathname } = pearLink('file:///path/to/file.js')
+  const { drive, protocol, pathname, origin } = pearLink('file:///path/to/file.js')
   t.is(drive.key, null)
   t.is(protocol, 'file:')
   t.is(pathname, '/path/to/file.js')
+  t.is(origin, 'file:///path/to/file.js')
 })
 
 test('relative path', (t) => {
@@ -147,22 +154,24 @@ test('url link normalize', (t) => {
   t.is(normalize('file://a/b/'), 'file://a/b')
 })
 
-test('url link origin', (t) => {
-  t.plan(4)
-  t.is(origin('file:///Users/user/app/'), 'file:///Users/user/app')
-  t.is(origin('pear://2.2455.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo/some/path#lochash'), 'pear://b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo')
-  t.is(origin('pear://keet/route/to/entry.js#fragment'), 'pear://keet')
-  t.is(origin('pear://future'), 'pear://future')
+test('origin', (t) => {
+  t.plan(6)
+  t.is(pearLink('file:///Users/user/app/').origin, 'file:///Users/user/app')
+  t.is(pearLink('pear://2.2455.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo/some/path#lochash').origin, 'pear://b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo')
+  t.is(pearLink('pear://keet/route/to/entry.js#fragment').origin, 'pear://keet')
+  t.is(pearLink('pear://oeeoz3w6fjjt7bym3ndpa6hhicm8f8naxyk11z4iypeoupn6jzpo').origin, 'pear://keet')
+  t.is(pearLink('pear://future').origin, 'pear://future')
+  t.is(pearLink('pear://future/route/to/entry.js#fragment').origin, 'pear://future')
 })
 
-test('Unix: url link origin', { skip: isWindows }, (t) => {
+test('origin: Unix', { skip: isWindows }, (t) => {
   t.plan(1)
-  t.is(origin('/Users/user/app/'), 'file:///Users/user/app')
+  t.is(pearLink('/Users/user/app/').origin, 'file:///Users/user/app')
 })
 
-test('Windows: url link origin', { skip: !isWindows }, (t) => {
+test('origin: Windows', { skip: !isWindows }, (t) => {
   t.plan(1)
-  t.is(origin('C:\\Users\\user\\app\\'), 'file:///C:/Users/user/app')
+  t.is(pearLink('C:\\Users\\user\\app\\').origin, 'file:///C:/Users/user/app')
 })
 
 function cwd () {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -148,11 +148,12 @@ test('url link normalize', (t) => {
 })
 
 test('url link origin', (t) => {
-  t.plan(4)
+  t.plan(5)
   t.is(origin('/Users/user/app/'), 'file:///Users/user/app')
   t.is(origin('file:///Users/user/app/'), 'file:///Users/user/app')
   t.is(origin('pear://2.2455.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo/some/path#lochash'), 'pear://b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo')
   t.is(origin('pear://keet/route/to/entry.js#fragment'), 'pear://keet')
+  t.is(origin('pear://future'), 'pear://future')
 })
 
 function cwd () {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -148,10 +148,11 @@ test('url link normalize', (t) => {
 })
 
 test('url link origin', (t) => {
-  t.plan(3)
-  t.is(origin('pear://keet/route/to/entry.html#fragment'), 'pear://keet')
-  t.is(origin('file:///Users/user/app/'), 'file:///Users/user/app')
+  t.plan(4)
   t.is(origin('/Users/user/app/'), 'file:///Users/user/app')
+  t.is(origin('file:///Users/user/app/'), 'file:///Users/user/app')
+  t.is(origin('pear://keet/route/to/entry.js#fragment'), 'pear://keet')
+  t.is(origin('pear://2.2455.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo/some/path#lochash', 'pear://b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo'))
 })
 
 function cwd () {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,7 +11,7 @@ const pearLink = require('../index.js')(ALIASES)
 const normalize = require('../index.js').normalize
 
 test('pear://<key>', (t) => {
-  t.plan(5)
+  t.plan(6)
   const { protocol, pathname, origin, drive: { length, fork, key } } = pearLink('pear://a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2')
   t.is(protocol, 'pear:')
   t.is(length, 0)
@@ -22,7 +22,7 @@ test('pear://<key>', (t) => {
 })
 
 test('pear://key/pathname', (t) => {
-  t.plan(5)
+  t.plan(6)
   const { protocol, pathname, origin, drive: { length, fork, key } } = pearLink('pear://a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2/some/path.js')
   t.is(protocol, 'pear:')
   t.is(length, 0)
@@ -40,7 +40,7 @@ test('pear://invalid-key', (t) => {
 })
 
 test('pear://<alias>', (t) => {
-  t.plan(6)
+  t.plan(7)
   const { protocol, pathname, origin, drive: { length, fork, key, alias } } = pearLink('pear://keet')
   t.is(protocol, 'pear:')
   t.is(length, 0)
@@ -52,7 +52,7 @@ test('pear://<alias>', (t) => {
 })
 
 test('pear://alias/path', (t) => {
-  t.plan(5)
+  t.plan(6)
   const { protocol, pathname, origin, drive: { length, fork, key } } = pearLink('pear://keet/some/path')
   t.is(protocol, 'pear:')
   t.is(length, 0)
@@ -63,7 +63,7 @@ test('pear://alias/path', (t) => {
 })
 
 test('pear://<fork>.<length>.<key>', (t) => {
-  t.plan(3)
+  t.plan(4)
   const { protocol, origin, drive } = pearLink('pear://2.2455.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo')
   t.is(protocol, 'pear:')
   t.is(drive.length, 2455)
@@ -72,7 +72,7 @@ test('pear://<fork>.<length>.<key>', (t) => {
 })
 
 test('pear://<fork>.<length>.<key>.<dhash>/some/path#lochash', (t) => {
-  t.plan(7)
+  t.plan(8)
   const { protocol, pathname, origin, drive, hash } = pearLink('pear://2.2455.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo/some/path#lochash')
   t.is(pathname, '/some/path')
   t.is(origin, 'pear://b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo')
@@ -85,7 +85,7 @@ test('pear://<fork>.<length>.<key>.<dhash>/some/path#lochash', (t) => {
 })
 
 test('pear://alias/path', (t) => {
-  t.plan(5)
+  t.plan(6)
   const { protocol, pathname, origin, drive: { length, fork, key } } = pearLink('pear://keet/some/path')
   t.is(protocol, 'pear:')
   t.is(length, 0)
@@ -96,7 +96,7 @@ test('pear://alias/path', (t) => {
 })
 
 test('file:///path', (t) => {
-  t.plan(3)
+  t.plan(4)
   const { drive, protocol, pathname, origin } = pearLink('file:///path/to/file.js')
   t.is(drive.key, null)
   t.is(protocol, 'file:')
@@ -155,13 +155,19 @@ test('url link normalize', (t) => {
 })
 
 test('origin', (t) => {
-  t.plan(6)
+  t.plan(5)
   t.is(pearLink('file:///Users/user/app/').origin, 'file:///Users/user/app')
   t.is(pearLink('pear://2.2455.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo.b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo/some/path#lochash').origin, 'pear://b9abnxwa71999xsweicj6ndya8w9w39z7ssg43pkohd76kzcgpmo')
   t.is(pearLink('pear://keet/route/to/entry.js#fragment').origin, 'pear://keet')
-  t.is(pearLink('pear://oeeoz3w6fjjt7bym3ndpa6hhicm8f8naxyk11z4iypeoupn6jzpo').origin, 'pear://keet')
   t.is(pearLink('pear://future').origin, 'pear://future')
   t.is(pearLink('pear://future/route/to/entry.js#fragment').origin, 'pear://future')
+})
+
+test('origin: keyToAlias', (t) => {
+  t.plan(3)
+  t.is(pearLink('pear://oeeoz3w6fjjt7bym3ndpa6hhicm8f8naxyk11z4iypeoupn6jzpo').origin, 'pear://keet')
+  t.is(pearLink('pear://oeeoz3w6fjjt7bym3ndpa6hhicm8f8naxyk11z4iypeoupn6jzpo/route/to/entry.js#fragment').origin, 'pear://keet')
+  t.is(pearLink('pear://nkw138nybdx6mtf98z497czxogzwje5yzu585c66ofba854gw3ro').origin, 'pear://runtime')
 })
 
 test('origin: Unix', { skip: isWindows }, (t) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,7 +9,7 @@ const ALIASES = {
 }
 const pearLink = require('../index.js')(ALIASES)
 const normalize = require('../index.js').normalize
-const root = require('../index.js').root
+const origin = require('../index.js').origin
 
 test('pear://<key>', (t) => {
   t.plan(5)
@@ -147,16 +147,11 @@ test('url link normalize', (t) => {
   t.is(normalize('file://a/b/'), 'file://a/b')
 })
 
-test('url link root', (t) => {
-  t.plan(7)
-  t.is(root('pear://keet/nested/#fragment'), 'pear://keet')
-  t.is(root('file:///Users/user/app/'), 'file:///Users/user/app')
-  const link = 'pear://a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2'
-  t.is(root(`${link}/`), link)
-  t.is(root(`${link}/#fragment`), link)
-  t.is(root(`${link}/nested`), link)
-  t.is(root(`${link}/nested/entrypoint.html`), link)
-  t.is(root(`${link}/nested/entrypoint.html#fragment`), link)
+test('url link origin', (t) => {
+  t.plan(3)
+  t.is(origin('pear://keet/route/to/entry.html#fragment'), 'pear://keet')
+  t.is(origin('file:///Users/user/app/'), 'file:///Users/user/app')
+  t.is(origin('/Users/user/app/'), 'file:///Users/user/app')
 })
 
 function cwd () {


### PR DESCRIPTION
Adds a helper function to normalize several types of 'pear links' to be used as primary-key for the collection `Bundle.link` on Pear.